### PR TITLE
vimix-gtk-theme: update to 20230909

### DIFF
--- a/package.yml
+++ b/package.yml
@@ -1,8 +1,8 @@
 name       : vimix-gtk-theme
-version    : '20230621'
-release    : 9
+version    : '20230909'
+release    : 10
 source     :
-    - https://github.com/vinceliuice/vimix-gtk-themes/archive/refs/tags/2023-06-21.tar.gz : 4a90c68ba2ac263bb3e7d82014e8257e4ffb36b5bf58158ecfb88fe7d50db94c
+    - https://github.com/vinceliuice/vimix-gtk-themes/archive/refs/tags/2023-09-09.tar.gz : 4f865b79d35abd459c9b9f0022ca0330539442761c5e667ae8b5c2cec44dccd0
 homepage   : https://github.com/vinceliuice/vimix-gtk-themes
 license    : GPL-3.0-only
 component  : desktop.theme

--- a/pspec_x86_64.xml
+++ b/pspec_x86_64.xml
@@ -18671,9 +18671,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="9">
-            <Date>2023-06-23</Date>
-            <Version>20230621</Version>
+        <Update release="10">
+            <Date>2023-09-11</Date>
+            <Version>20230909</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
### Summary

vimix-gtk-theme: update to 20230909

**Release Notes:**
- Fixed Budgie issues

Full commit log available [here](https://github.com/vinceliuice/vimix-gtk-themes/compare/2023-06-21...2023-09-09)

### Test Plan

Chose a number of the provided Vimix varations as my GTK widget theme and checked that things looked alright

### Checklist

- [x] Package was built and tested against unstable
